### PR TITLE
Add formatting check script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Minix3 Fine-Grain Repository
+
+This repository contains the Minix3 operating system source code used for research and development.
+
+## Format Check Script
+
+The `scripts/check_format.sh` script runs basic format and lint checks on the project.
+
+### Usage
+
+```bash
+./scripts/check_format.sh
+```
+
+The script performs the following steps:
+
+1. Runs **flake8** on selected Python directories.
+2. Runs **black --check** on the same directories.
+3. Runs **shellcheck** on every `*.sh` file in the repository.
+
+The script exits with a non-zero status code if any of these tools report problems.

--- a/scripts/check_format.sh
+++ b/scripts/check_format.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# check_format.sh - Run formatting and lint checks for the project.
+#
+# This script runs flake8 and black on Python directories and
+# shellcheck on all shell scripts. It exits with a non-zero status if
+# any of the tools report an error.
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+# Directories containing Python code to check. Add more directories as needed.
+PY_DIRS="scripts tools releasetools"
+
+# Build a list of existing directories to avoid errors.
+EXISTING_PY_DIRS=""
+for dir in $PY_DIRS; do
+    if [ -d "$dir" ]; then
+        EXISTING_PY_DIRS="$EXISTING_PY_DIRS $dir"
+    fi
+done
+
+# Run Python linters and formatters when directories are present.
+if [ -n "$EXISTING_PY_DIRS" ]; then
+    echo "Running flake8 on:$EXISTING_PY_DIRS"
+    flake8 $EXISTING_PY_DIRS
+
+    echo "Running black --check on:$EXISTING_PY_DIRS"
+    black --check $EXISTING_PY_DIRS
+fi
+
+# Find all shell scripts and run shellcheck on them.
+# The find command searches the entire repository for files ending in .sh.
+if command -v shellcheck >/dev/null 2>&1; then
+    echo "Running shellcheck on all shell scripts"
+    find . -name '*.sh' -print0 | xargs -0 shellcheck
+else
+    echo "shellcheck not found" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- add a `scripts/check_format.sh` helper
- document how to run the format check in `README.md`

## Testing
- `./scripts/check_format.sh` *(fails: flake8/black have no python files; shellcheck reports many issues)*

------
https://chatgpt.com/codex/tasks/task_e_6845dd34c5e4833192b1608070acea24

## Summary by Sourcery

Add a new helper script to automate project-wide lint and format checks and document its usage in the README

New Features:
- Introduce scripts/check_format.sh to run flake8, black --check, and shellcheck across the repository

Documentation:
- Add a section to README.md describing how to use the format check script